### PR TITLE
Fix fast-xml-parser vulnerability via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
-                "@lwc/engine-server": "^9.1.3",
                 "@lwc/jest-preset": "^19.6.0",
                 "@rollup/plugin-replace": "^6.0.3",
                 "@salesforce/eslint-config-lwc": "^4.1.2",
@@ -3205,6 +3204,7 @@
             "integrity": "sha512-esckknDi0fv8EYLLj+Tb+CHzqYyikmlgAqwvk/Q4YWZxOdmuA9Emk6cStpYBkDAzm+7MRUjyXmK6L/2/kl5JaQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.6.0"
             }
@@ -3608,6 +3608,19 @@
             "dependencies": {
                 "eslint-scope": "5.1.1"
             }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -10928,9 +10941,9 @@
             "peer": true
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
+            "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
             "dev": true,
             "funding": [
                 {
@@ -10944,9 +10957,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.12",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
-            "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
             "dev": true,
             "funding": [
                 {
@@ -10956,7 +10969,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.4",
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.7",
                 "path-expression-matcher": "^1.5.0",
                 "strnum": "^2.2.3"
             },
@@ -19689,47 +19703,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/webdriver/node_modules/edgedriver": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.6.1.tgz",
-            "integrity": "sha512-3Ve9cd5ziLByUdigw6zovVeWJjVs8QHVmqOB0sJ0WNeVPcwf4p18GnxMmVvlFmYRloUwf5suNuorea4QzwBIOA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@wdio/logger": "^8.38.0",
-                "@zip.js/zip.js": "^2.7.48",
-                "decamelize": "^6.0.0",
-                "edge-paths": "^3.0.5",
-                "fast-xml-parser": "^4.4.1",
-                "node-fetch": "^3.3.2",
-                "which": "^4.0.0"
-            },
-            "bin": {
-                "edgedriver": "bin/edgedriver.js"
-            }
-        },
-        "node_modules/webdriver/node_modules/fast-xml-parser": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-            "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
-        },
         "node_modules/webdriver/node_modules/geckodriver": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
@@ -19873,20 +19846,6 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
-        },
-        "node_modules/webdriver/node_modules/strnum": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-            "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/webdriver/node_modules/undici-types": {
             "version": "6.21.0",
@@ -20147,47 +20106,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/webdriverio/node_modules/edgedriver": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.6.1.tgz",
-            "integrity": "sha512-3Ve9cd5ziLByUdigw6zovVeWJjVs8QHVmqOB0sJ0WNeVPcwf4p18GnxMmVvlFmYRloUwf5suNuorea4QzwBIOA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@wdio/logger": "^8.38.0",
-                "@zip.js/zip.js": "^2.7.48",
-                "decamelize": "^6.0.0",
-                "edge-paths": "^3.0.5",
-                "fast-xml-parser": "^4.4.1",
-                "node-fetch": "^3.3.2",
-                "which": "^4.0.0"
-            },
-            "bin": {
-                "edgedriver": "bin/edgedriver.js"
-            }
-        },
-        "node_modules/webdriverio/node_modules/fast-xml-parser": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
-            "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
-        },
         "node_modules/webdriverio/node_modules/geckodriver": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
@@ -20331,20 +20249,6 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
-        },
-        "node_modules/webdriverio/node_modules/strnum": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-            "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/webdriverio/node_modules/undici-types": {
             "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
         "wdio-utam-service": "^3.3.0"
     },
     "overrides": {
+        "edgedriver": "^6.1.2",
+        "fast-xml-parser": "^5.7.3",
         "jsondiffpatch": "^0.7.3",
         "serialize-javascript": "^7.0.5",
         "tar-fs": "^3.1.2",


### PR DESCRIPTION
## Summary

- Adds `"edgedriver": "^6.1.2"` to `overrides` — forces all edgedriver instances to 6.x, eliminating the nested `edgedriver@5.6.1` instances (under `webdriver` and `webdriverio`) that pulled in the vulnerable `fast-xml-parser@4.x`
- Adds `"fast-xml-parser": "^5.7.3"` to `overrides` — ensures the latest patched 5.x version is used everywhere (`5.5.12` had a separate moderate CVE fixed in `5.7.0`)

**Root-cause chain:**
`wdio-geckodriver-service@5` (v8-era) → `@wdio/utils@8.46.0` (nested peer dep) → `edgedriver@^5.5.0` → `edgedriver@5.6.1` → `fast-xml-parser@^4.4.1` → `fast-xml-parser@4.5.6` ← vulnerable, no patch in ^4 range

The override for `edgedriver` is safe because the project only runs Firefox tests — edgedriver (Edge browser driver) is never invoked at runtime.

## Test plan

- [x] `npm ls fast-xml-parser` shows only `5.7.3` — no `4.x` instances
- [x] `npm audit` no longer flags `fast-xml-parser`
- [x] `npm run test:unit` — 30/30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)