### PR TITLE
Fix axios, postcss, and basic-ftp vulnerabilities via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7459,13 +7459,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -7750,9 +7750,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16254,9 +16254,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
         "wdio-utam-service": "^3.3.0"
     },
     "overrides": {
+        "axios": "^1.16.0",
+        "basic-ftp": "^5.3.1",
         "edgedriver": "^6.1.2",
         "fast-xml-parser": "^5.7.3",
         "jsondiffpatch": "^0.7.3",
+        "postcss": "^8.5.14",
         "serialize-javascript": "^7.0.5",
         "tar-fs": "^3.1.2",
         "ws": "^8.18.0"


### PR DESCRIPTION
## Summary

Fixes all remaining Dependabot alerts using npm `overrides` (same pattern as the recent fast-xml-parser fix). All three are transitive dependencies with no direct upgrade path.

| Package | Via | Vulnerable | Fixed |
|---|---|---|---|
| `axios` | `start-server-and-test → wait-on` | `<1.15.1` (9 CVEs, 2 high) | `^1.16.0` |
| `postcss` | `lwc → @lwc/style-compiler` | `<8.5.10` (moderate) | `^8.5.14` |
| `basic-ftp` | `@wdio/cli → @puppeteer/browsers → get-uri` | `<=5.2.2` (high) | `^5.3.1` |

Supersedes Dependabot PR #34 (lock-file-only axios bump) with a durable `package.json` override that survives lock file regeneration.

`npm audit` reports **0 vulnerabilities** after this change.

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run test:unit` — 30/30 tests pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)